### PR TITLE
feat: enable Scala 3 cross-build and modernize build settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,11 +44,10 @@ lazy val baseSettings = Seq(
     ) ++ crossScalacOptions(scalaVersion.value)
   ),
   javacOptions ++= Seq("--release", "17"),
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases"),
-    "Seasar Repository" at "https://maven.seasar.org/maven2/"
-  ),
+  resolvers ++=
+    Resolver.sonatypeOssRepos("snapshots") ++
+      Resolver.sonatypeOssRepos("releases") ++
+      Seq("Seasar Repository" at "https://maven.seasar.org/maven2/"),
   Test / publishArtifact := false,
   Test / fork := true,
   Test / parallelExecution := false,
@@ -61,12 +60,7 @@ lazy val baseSettings = Seq(
     }
   },
   semanticdbEnabled := true,
-  semanticdbVersion := "4.14.2",
-  // Remove me when scalafix is stable and feature-complete on Scala 3
-  ThisBuild / scalafixScalaBinaryVersion := (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, _)) => CrossVersion.binaryScalaVersion(scalaVersion.value)
-    case _ => CrossVersion.binaryScalaVersion(Versions.scala212Version)
-  })
+  semanticdbVersion := "4.14.2"
 )
 
 val root = (project in file("."))


### PR DESCRIPTION
## Summary
- Enable Scala 3.3.7 LTS cross-build (previously `crossScalaVersions` was commented out)
- Update Scala versions: 2.13.14 → 2.13.18, 2.12.19 → 2.12.21, 3.0.0 → 3.3.7
- Use native Scala 3 fastparse artifact instead of `CrossVersion.for3Use2_13`
- Upgrade target JVM from 1.8 to 17
- Update CI workflows (actions v5, add lint step)
- Improve scalafix/scalafmt configurations
- Remove deprecated sbt settings (`Resolver.sonatypeRepo`, `scalafixScalaBinaryVersion`)
- Add agent configuration files (Claude, Codex, etc.)

## Test plan
- [x] `sbt "+test"` passes on both Scala 2.13.18 and Scala 3.3.7 (26 tests each)
- [x] Build compiles cleanly with no deprecation warnings in build.sbt
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change: updates resolver configuration and removes a deprecated scalafix binary-version override, which may affect dependency resolution or linting behavior but not runtime code.
> 
> **Overview**
> Modernizes `build.sbt` by switching from deprecated `Resolver.sonatypeRepo` to `Resolver.sonatypeOssRepos` and simplifying the resolver list.
> 
> Removes the `scalafixScalaBinaryVersion` override (previously used as a Scala 3 workaround) while keeping `semanticdb` enabled at version `4.14.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d458240891101c3bf2eda806217f1e44cc64452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->