### PR TITLE
Fix/update 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
         cache: 'sbt'
-    - uses: coursier/cache-action@v7
+    - uses: sbt/setup-sbt@v1
     - uses: olafurpg/setup-gpg@v3
     - run: sbt -v ci-release
       env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,6 +12,9 @@ jobs:
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -22,13 +25,21 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
         cache: 'sbt'
-    - uses: coursier/cache-action@v7
-    - uses: olafurpg/setup-gpg@v3
-    - run: sbt -v ci-release
-      env:
-        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-    - name: clean up
-      run: "${GITHUB_WORKSPACE}/.github/clean-up.sh"
+    - uses: sbt/setup-sbt@v1
+    - name: Configure Sonatype credentials
+      run: |
+        mkdir -p ~/.sbt/1.0
+        cat > ~/.sbt/1.0/sonatype_credentials <<EOF
+        realm=Sonatype Nexus Repository Manager
+        host=central.sonatype.com
+        user=$SONATYPE_USERNAME
+        password=$SONATYPE_PASSWORD
+        EOF
+    - name: Import GPG key
+      run: |
+        echo "${{ secrets.PGP_SECRET }}" | base64 -d | gpg --batch --import
+    - name: Publish Snapshot
+      run: |
+        sbt \
+          'set every publishTo := Some("central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")' \
+          +publishSigned

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,27 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "chronos-parser-scala"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Dependencies.Versions
 
+ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "1.0" / "sonatype_credentials")
+
 def crossScalacOptions(scalaVersion: String): Seq[String] =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((3L, _)) =>
@@ -44,10 +46,10 @@ lazy val baseSettings = Seq(
     ) ++ crossScalacOptions(scalaVersion.value)
   ),
   javacOptions ++= Seq("--release", "17"),
-  resolvers ++=
-    Resolver.sonatypeOssRepos("snapshots") ++
-      Resolver.sonatypeOssRepos("releases") ++
-      Seq("Seasar Repository" at "https://maven.seasar.org/maven2/"),
+  resolvers ++= Seq(
+    Resolver.sonatypeCentralSnapshots,
+    "Seasar Repository" at "https://maven.seasar.org/maven2/"
+  ),
   Test / publishArtifact := false,
   Test / fork := true,
   Test / parallelExecution := false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI publishing flows and credential/GPG handling; a misconfiguration could break releases or snapshots, but it doesn’t affect runtime/library code.
> 
> **Overview**
> Updates CI publishing to align with Sonatype Central. The `release` workflow swaps `coursier/cache-action` for `sbt/setup-sbt`, and the `snapshot` workflow is reworked to write a Sonatype credentials file, import the GPG key manually, and publish signed artifacts to the Central snapshots repository.
> 
> Build config now loads credentials from `~/.sbt/1.0/sonatype_credentials` and simplifies resolvers to use `Resolver.sonatypeCentralSnapshots` (dropping the older OSS snapshots/releases resolver list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b44daa49853e555ae7ddc6226ada6b374acaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->