### PR TITLE
fix: remove setup-gpg action and add credentials file to release work…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -19,10 +21,16 @@ jobs:
         java-version: '17'
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
-    - uses: olafurpg/setup-gpg@v3
+    - name: Configure Sonatype credentials
+      run: |
+        mkdir -p ~/.sbt/1.0
+        cat > ~/.sbt/1.0/sonatype_credentials <<EOF
+        realm=Sonatype Nexus Repository Manager
+        host=central.sonatype.com
+        user=$SONATYPE_USERNAME
+        password=$SONATYPE_PASSWORD
+        EOF
     - run: sbt -v ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
…flow

- Remove olafurpg/setup-gpg@v3 (conflicts with sbt-ci-release 1.11+ which handles GPG import internally via PGP_SECRET env var)
- Add Sonatype credentials file creation step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts how secrets are provided to the release job; failures would be limited to the GitHub Actions release pipeline.
> 
> **Overview**
> Updates the `Release` GitHub Actions workflow to stop using `olafurpg/setup-gpg@v3` and rely on `sbt ci-release`/`PGP_SECRET` handling instead.
> 
> Adds a step that writes a `~/.sbt/1.0/sonatype_credentials` file from `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` secrets, moving Sonatype creds from per-step env into the job environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0322053796aad4e21e7f364ffe6eae5b51b20a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->