### PR TITLE
fix: fix GPG homedir permissions and add key import verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,12 @@ jobs:
     - name: Configure GPG agent for loopback pinentry
       run: |
         mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
         echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-        gpgconf --reload gpg-agent || true
+        chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
+        gpg-agent --daemon || true
     - run: sbt -v ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,11 +38,15 @@ jobs:
     - name: Import GPG key
       run: |
         mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
         echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-        gpgconf --reload gpg-agent || true
+        chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
+        gpg-agent --daemon || true
         echo "${{ secrets.PGP_SECRET }}" | base64 -d | gpg --batch --import
+        echo "--- Verifying GPG key import ---"
+        gpg --list-secret-keys
     - name: Publish Snapshot
       run: |
         sbt \


### PR DESCRIPTION
- chmod 700 ~/.gnupg and chmod 600 on config files (GPG requires strict permissions, otherwise refuses to use secret keys)
- Start gpg-agent daemon explicitly before key import
- Add gpg --list-secret-keys after import to verify key availability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that tighten GPG file permissions and make the signing environment more deterministic; main risk is CI publishing failures if the agent startup/permissions behave differently across runners.
> 
> **Overview**
> Improves CI publishing reliability by **hardening GPG setup** in both `release.yml` and `snapshot.yml`: enforces strict `~/.gnupg` and config file permissions and explicitly starts `gpg-agent` for loopback pinentry.
> 
> The snapshot workflow now also **verifies secret key availability** after import by running `gpg --list-secret-keys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2decfddb8555a95858abd577d45490b379bfce81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->