### PR TITLE
fix: use printf for credentials file to avoid heredoc indentation issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,8 @@ jobs:
     - name: Configure Sonatype credentials
       run: |
         mkdir -p ~/.sbt/1.0
-        cat > ~/.sbt/1.0/sonatype_credentials <<EOF
-        realm=Sonatype Nexus Repository Manager
-        host=central.sonatype.com
-        user=$SONATYPE_USERNAME
-        password=$SONATYPE_PASSWORD
-        EOF
+        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+          "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
     - name: Configure GPG agent for loopback pinentry
       run: |
         mkdir -p ~/.gnupg

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,12 +29,9 @@ jobs:
     - name: Configure Sonatype credentials
       run: |
         mkdir -p ~/.sbt/1.0
-        cat > ~/.sbt/1.0/sonatype_credentials <<EOF
-        realm=Sonatype Nexus Repository Manager
-        host=central.sonatype.com
-        user=$SONATYPE_USERNAME
-        password=$SONATYPE_PASSWORD
-        EOF
+        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+          "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
+        cat ~/.sbt/1.0/sonatype_credentials | sed 's/password=.*/password=***/'
     - name: Import GPG key
       run: |
         mkdir -p ~/.gnupg
@@ -45,7 +42,6 @@ jobs:
         chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
         gpg-agent --daemon || true
         echo "${{ secrets.PGP_SECRET }}" | base64 -d | gpg --batch --import
-        echo "--- Verifying GPG key import ---"
         gpg --list-secret-keys
     - name: Publish Snapshot
       run: |


### PR DESCRIPTION
Also add debug output (masked) to verify credentials file format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks GitHub Actions publishing workflows; main risk is misformatting the Sonatype credentials file and breaking release/snapshot publishing.
> 
> **Overview**
> Updates the release and snapshot GitHub Actions workflows to generate `~/.sbt/1.0/sonatype_credentials` via `printf` (instead of a heredoc) to avoid indentation/formatting issues.
> 
> The snapshot workflow now prints the generated credentials file with the password masked to help debug publishing failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323b2b8d6ddc0ad4788afe7f4b7b1d18238e7757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->